### PR TITLE
Update MCSPV for heterogeneous v0

### DIFF
--- a/src/CurrentModes.jl
+++ b/src/CurrentModes.jl
@@ -118,7 +118,7 @@ and n_j = (cosθ_j, sinθ_j) is the orientation vector of the active force. Both
 - `s::MCSPVSimulation`: A multi-component SPV simulation object.
 """
 function calculate_total_force(s::MCSPVSimulation)
-    Ftot = [zeros(s.Ndims, s.N, s.Nt) for i=1:s.Ns]
+    Ftot = [zeros(s.Ndims, s.N_particles_per_species[i], s.Nt) for i=1:s.N_species]
 
     for i=1:s.N_species
         f = s.F_array[i]; u = s.u_array[i]; v0 = s.v0[i]; μ = s.mobility[i]

--- a/src/CurrentModes.jl
+++ b/src/CurrentModes.jl
@@ -111,7 +111,7 @@ end
 
 Calculates the total force on every particle, scaled by the mobility, for all timesteps and all species in a multi-component Self-Propelled Voronoi simulation.
     
-The total force is defined as: Ftot_j = μ Fint_j + v0 n_j, where Fint_j is the interaction force, 
+The total force is defined as: Ftot_j = μ Fint_j + v0 n_j, where Fint_j is the interaction force, v0 is the single-particle active force strength
 and n_j = (cosθ_j, sinθ_j) is the orientation vector of the active force. Both forces are time-dependent.
 
 # Arguments

--- a/src/CurrentModes.jl
+++ b/src/CurrentModes.jl
@@ -118,7 +118,7 @@ and n_j = (cosθ_j, sinθ_j) is the orientation vector of the active force. Both
 - `s::MCSPVSimulation`: A multi-component SPV simulation object.
 """
 function calculate_total_force(s::MCSPVSimulation)
-    Ftot = zero(s.F_array);
+    Ftot = [zeros(s.Ndims, s.N, s.Nt) for i=1:s.Ns]
 
     for i=1:s.N_species
         f = s.F_array[i]; u = s.u_array[i]; v0 = s.v0[i]; μ = s.mobility[i]

--- a/src/LoadData.jl
+++ b/src/LoadData.jl
@@ -34,9 +34,8 @@ function read_SPV_simulation(traj, params; dt_array=nothing, t1_t2_pair_array=no
     A = traj.areas_trajectory |> stack
     P = traj.perimeters_trajectory |> stack
     steps_saved = traj.steps_saved
-    v0 = params.particles.active_force_strengths[1]
+    v0 = params.particles.active_force_strengths[1]  # single-component: only one v0 value
     mobility = 1.0 / params.frictionconstant
-    @assert all([params.particles.active_force_strengths[i] == v0 for i=1:params.N]) "Particles belonging to one species should have the same active force strength!"
 
     dt = params.dt
     dims = size(r, 1)
@@ -146,7 +145,7 @@ function read_SPV_simulation_multicomponent(traj, params, species::Vector{Int}; 
     fvec = Array{Array{Float64, 3}, 1}(undef, N_species)
     Avec = Array{Array{Float64, 2}, 1}(undef, N_species)
     Pvec = Array{Array{Float64, 2}, 1}(undef, N_species)
-    vvec = Array{Float64, 1}(undef, N_species)
+    vvec = Array{Array{Float64, 1}, 1}(undef, N_species)
     μvec = Array{Float64, 1}(undef, N_species)  
     # friction constant in the SPV model is the same for all species, but here we treat it "per species" for generality
     Epotvec = Array{Float64, 1}(undef, N_species)
@@ -158,8 +157,7 @@ function read_SPV_simulation_multicomponent(traj, params, species::Vector{Int}; 
         Avec[i] = A[indices, :]
         Pvec[i] = P[indices, :]
         # Epotvec[i] = Epot[indices]   # this is not saved per particle / species
-        @assert all( [v0[indices][i] == v0[indices][1] for i=eachindex(indices)] ) "Particles belonging to one species should have the same active force strength!"
-        vvec[i] = v0[indices][1]
+        vvec[i] = v0[indices]
         μvec[i] = 1.0 / params.frictionconstant  # THIS IS THE SAME FOR EVERY SPECIES! (can change later if needed)
     end
     Epotvec = Epot

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -128,7 +128,7 @@ A mutable struct that holds all data for a multi-component self-propelled Vorono
 - `N_species::Int64`: Number of different particle species.
 - `Nt::Int64`: Number of time steps.
 - `dt::Float64`: Time step size.
-- `v0::Vector{Float64}`: A vector containing the active force strength of each species.
+- `v0::Vector{Vector{Float64}}`: A vector containing the active force strengths of each particle.
 - `mobility::Vector{Float64}`: A vector containing the mobility (inverse of the friction constant) of each species.
 - `N_particles_per_species::Vector{Int}`: A vector containing the number of particles for each species.
 - `r_array::Vector{Array{Float64, 3}}`: A vector of particle position arrays. Each element `r_array[i]` is a `(N_particles_per_species[i], Ndims, N_time_steps)` array for species `i`.
@@ -149,7 +149,7 @@ struct MCSPVSimulation <: Simulation
     N_species::Int64
     Nt::Int64
     dt::Float64
-    v0::Vector{Float64}
+    v0::Vector{Array{Float64,1}}
     mobility::Vector{Float64}
     N_particles_per_species::Vector{Int}
     r_array::Vector{Array{Float64, 3}}

--- a/test/test_velocity_correlations.jl
+++ b/test/test_velocity_correlations.jl
@@ -208,8 +208,8 @@ sim4 = MCSPVSimulation(
     sim_MC.mobility,
     sim_MC.N_particles_per_species,
     sim_MC.r_array,
-    [zeros(sim_MC.N, sim_MC.Nt) for i=1:sim_MC.Ns],  # orientations
-    [zeros(sim_MC.Ndims, sim_MC.N, sim_MC.Nt) for i=1:sim_MC.Ns],  # forces
+    [zeros(sim_MC.N_particles_per_species[i], sim_MC.Nt) for i=1:sim_MC.N_species],  # orientations
+    [zeros(sim_MC.Ndims, sim_MC.N_particles_per_species[i], sim_MC.Nt) for i=1:sim_MC.N_species],  # forces
     sim_MC.perimeter_array,
     sim_MC.area_array,
     sim_MC.Epot_array,

--- a/test/test_velocity_correlations.jl
+++ b/test/test_velocity_correlations.jl
@@ -172,7 +172,7 @@ sim3 = SelfPropelledVoronoiSimulation(
     sim.mobility,
     sim.r_array,
     sim.u_array,
-    zero(sim.F_array),
+    zeros(sim.Ndims, sim.N, sim.Nt),
     sim.perimeter_array,
     sim.area_array,
     sim.Epot_array,
@@ -198,9 +198,6 @@ push!(v0_MC, ones(200))
 
 sim_MC = SimulationAnalysis.read_SPV_simulation_multicomponent(traj, params, species)
 
-u_zeros = [zeros(200,sim_MC.Nt), zeros(200,sim_MC.Nt)]
-F_zeros = [zeros(2,200,sim_MC.Nt), zeros(2,200,sim_MC.Nt)]
-
 sim4 = MCSPVSimulation(
     400,
     sim_MC.Ndims,
@@ -211,8 +208,8 @@ sim4 = MCSPVSimulation(
     sim_MC.mobility,
     sim_MC.N_particles_per_species,
     sim_MC.r_array,
-    u_zeros,
-    F_zeros,
+    [zeros(s.N, s.Nt) for i=1:s.Ns],  # orientations
+    [zeros(s.Ndims, s.N, s.Nt) for i=1:s.Ns],  # forces
     sim_MC.perimeter_array,
     sim_MC.area_array,
     sim_MC.Epot_array,

--- a/test/test_velocity_correlations.jl
+++ b/test/test_velocity_correlations.jl
@@ -198,6 +198,9 @@ push!(v0_MC, ones(200))
 
 sim_MC = SimulationAnalysis.read_SPV_simulation_multicomponent(traj, params, species)
 
+u_zeros = [zeros(200,sim_MC.Nt), zeros(200,sim_MC.Nt)]
+F_zeros = [zeros(2,200,sim_MC.Nt), zeros(2,200,sim_MC.Nt)]
+
 sim4 = MCSPVSimulation(
     400,
     sim_MC.Ndims,
@@ -208,8 +211,8 @@ sim4 = MCSPVSimulation(
     sim_MC.mobility,
     sim_MC.N_particles_per_species,
     sim_MC.r_array,
-    zero(sim_MC.u_array),  # replace orientations by zeros
-    zero(sim_MC.F_array),
+    u_zeros,
+    F_zeros,
     sim_MC.perimeter_array,
     sim_MC.area_array,
     sim_MC.Epot_array,

--- a/test/test_velocity_correlations.jl
+++ b/test/test_velocity_correlations.jl
@@ -208,8 +208,8 @@ sim4 = MCSPVSimulation(
     sim_MC.mobility,
     sim_MC.N_particles_per_species,
     sim_MC.r_array,
-    [zeros(s.N, s.Nt) for i=1:s.Ns],  # orientations
-    [zeros(s.Ndims, s.N, s.Nt) for i=1:s.Ns],  # forces
+    [zeros(sim_MC.N, sim_MC.Nt) for i=1:sim_MC.Ns],  # orientations
+    [zeros(sim_MC.Ndims, sim_MC.N, sim_MC.Nt) for i=1:sim_MC.Ns],  # forces
     sim_MC.perimeter_array,
     sim_MC.area_array,
     sim_MC.Epot_array,

--- a/test/test_velocity_correlations.jl
+++ b/test/test_velocity_correlations.jl
@@ -186,3 +186,43 @@ sim3 = SelfPropelledVoronoiSimulation(
 Ftot3 = SimulationAnalysis.calculate_total_force(sim3);
 @test sim3.F_array != Ftot3
 @test Ftot3[1,:,:] == sim3.v0 / sim3.mobility * cos.(sim.u_array)
+
+
+# multicomponent test: force calculation
+species = Int.(ones(400))
+species[201:400] .= 2
+
+v0_MC = []
+push!(v0_MC, 10*ones(200))
+push!(v0_MC, ones(200))
+
+sim_MC = SimulationAnalysis.read_SPV_simulation_multicomponent(traj, params, species)
+
+sim4 = MCSPVSimulation(
+    400,
+    sim_MC.Ndims,
+    2,
+    sim_MC.Nt,
+    sim_MC.dt,
+    v0_MC,
+    sim_MC.mobility,
+    sim_MC.N_particles_per_species,
+    sim_MC.r_array,
+    zero(sim_MC.u_array),  # replace orientations by zeros
+    zero(sim_MC.F_array),
+    sim_MC.perimeter_array,
+    sim_MC.area_array,
+    sim_MC.Epot_array,
+    sim_MC.t_array,
+    sim_MC.box_sizes,
+    sim_MC.dt_array,
+    sim_MC.t1_t2_pair_array,
+    ""
+)
+
+forces = SimulationAnalysis.calculate_total_force(sim4)
+
+@test all(forces[1][1,:,:] .== 10.0)
+@test all(forces[1][2,:,:] .== 0.0)
+@test all(forces[2][1,:,:] .== 1.0)
+@test all(forces[2][2,:,:] .== 0.0)


### PR DESCRIPTION
- Changed `MCSPV` object to store all values of v0 per species (and not just the first value of each)
- Removed unnecessary AssertionError that ensures that all particles in species have the same v0 (this doesn't work for continuous distributions)
- Added small test case for heterogeneous v0 force calculation